### PR TITLE
RequestLocalTime and its sample usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
-# finatra-thrift-simple-sample
-[![Build Status](https://travis-ci.org/laysakura/finatra-thrift-simple-sample.svg?branch=master)](https://travis-ci.org/laysakura/finatra-thrift-simple-sample)
+# finatra-request-local-time
+[![Build Status](https://travis-ci.org/laysakura/finatra-request-local-time.svg?branch=master)](https://travis-ci.org/laysakura/finatra-request-local-time)
 
-A simple sample project using finatra-thrift.
+Provides `RequestLocalTime.current.requestedAt` , which is a consistent timestamp among a request-response lifetime.
+
+## Usage
+See https://github.com/laysakura/finatra-request-local-time/pull/1 for an example usage.
+
+### Setting `SetRequestLocalTimeFilter`
+```scala
+import com.github.laysakura.requestlocaltime.filters.SetRequestLocalTimeFilter
+import com.twitter.finatra.thrift.ThriftServer
+import com.twitter.finatra.thrift.routing.ThriftRouter
+
+class YourServer extends ThriftServer
+{
+  // ...
+
+  override def configureThrift(router: ThriftRouter) {
+    router
+      // other filters ...
+      .filter[SetRequestLocalTimeFilter]
+      .add[YourController]
+  }
+}
+```
+
+### Accessing `RequestLocalTime.current.requestedAt`
+It can be accessed from anywhere if the code path is reached by a request.

--- a/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/controllers/VerboseServiceController.scala
+++ b/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/controllers/VerboseServiceController.scala
@@ -1,5 +1,8 @@
 package com.github.laysakura.requestlocaltime.controllers
 
+import java.time.OffsetDateTime
+
+import com.github.laysakura.requestlocaltime.filters.RequestLocalTime
 import com.github.laysakura.requestlocaltime.idl
 import com.github.laysakura.requestlocaltime.idl.VerboseService.Echo
 import com.google.inject.{Inject, Singleton}
@@ -14,10 +17,12 @@ class VerboseServiceController @Inject() ()
     with Logging
 {
   override val echo = handle(Echo) { args =>
-    debug(s"""debug!\n\tyou said "${args.message}"""")
-    info(s"""info!\n\tyou said "${args.message}"""")
-    warn(s"""warn!\n\tyou said "${args.message}"""")
-    error(s"""error!\n\tyou said "${args.message}"""")
+    info(s"Current time: ${OffsetDateTime.now}\tRequestLocalTime=${RequestLocalTime.current.requestedAt}")
+
+    debug("sleeping...")
+    Thread.sleep(1000)
+
+    info(s"Current time: ${OffsetDateTime.now}\tRequestLocalTime=${RequestLocalTime.current.requestedAt}")
 
     Future(s"You said: ${args.message}")
   }

--- a/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/filters/RequestLocalTime.scala
+++ b/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/filters/RequestLocalTime.scala
@@ -1,0 +1,31 @@
+package com.github.laysakura.requestlocaltime.filters
+
+import java.time.OffsetDateTime
+
+import com.twitter.finagle.Service
+import com.twitter.finagle.context.Contexts
+import com.twitter.finatra.thrift.{ThriftFilter, ThriftRequest}
+import com.twitter.util.Future
+
+case class RequestLocalTime(requestedAt: OffsetDateTime) {
+  /**
+    * f を実行している間は、 RequestLocalTime.current.requestedAt で、常に同一の時刻（リクエスト時点のもの）が見える。
+    */
+  def asCurrent[T](f: => T): T = RequestLocalTime.let(this)(f)
+}
+
+object RequestLocalTime {
+  private val ctx = new Contexts.local.Key[RequestLocalTime]
+
+  def current: RequestLocalTime = Contexts.local.get(ctx).get
+
+  private def let[R](requestedAt: RequestLocalTime)(f: => R): R =
+    Contexts.local.let(ctx, requestedAt)(f)
+}
+
+class SetRequestLocalTimeFilter extends ThriftFilter {
+  override def apply[T, U](request: ThriftRequest[T], service: Service[ThriftRequest[T], U]): Future[U] =
+    RequestLocalTime(OffsetDateTime.now).asCurrent {
+      service(request)
+    }
+}

--- a/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/server/VerboseServiceServer.scala
+++ b/verboseService/src/main/scala/com/github/laysakura/requestlocaltime/server/VerboseServiceServer.scala
@@ -1,6 +1,7 @@
 package com.github.laysakura.requestlocaltime.server
 
 import com.github.laysakura.requestlocaltime.controllers.VerboseServiceController
+import com.github.laysakura.requestlocaltime.filters.SetRequestLocalTimeFilter
 import com.github.laysakura.requestlocaltime.modules.ClientIdModule
 import com.twitter.finatra.thrift.ThriftServer
 import com.twitter.finatra.thrift
@@ -26,6 +27,7 @@ class VerboseServiceServer extends ThriftServer
       .filter[thrift.filters.ThriftMDCFilter]
       .filter[thrift.filters.AccessLoggingFilter]
       .filter[thrift.filters.StatsFilter]
+      .filter[SetRequestLocalTimeFilter]
       .add[VerboseServiceController]
   }
 }


### PR DESCRIPTION
Log from https://travis-ci.org/laysakura/finatra-request-local-time/builds/200352411#L1312-L1316

```
14:03:37.326 [finagle/netty3-2] INFO  c.g.l.r.c.VerboseServiceController - Current time: 2017-02-10T14:03:37.326Z	RequestLocalTime=2017-02-10T14:03:37.321Z
14:03:37.327 [finagle/netty3-2] DEBUG c.g.l.r.c.VerboseServiceController - sleeping...
14:03:38.328 [finagle/netty3-2] INFO  c.g.l.r.c.VerboseServiceController - Current time: 2017-02-10T14:03:38.328Z	RequestLocalTime=2017-02-10T14:03:37.321Z
```

Note that `RequestLocalTime=2017-02-10T14:03:37.321Z` even with 1 second sleep ⏲ 